### PR TITLE
set a path-alias to the vite.config.ts

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import solidPlugin from 'vite-plugin-solid'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      src: path.resolve(__dirname, '../src'),
+    },
+  },
   plugins: [
     solidPlugin(),
     {

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from 'vite'
 import solidPlugin from 'vite-plugin-solid'
-import path from 'path'
 
 export default defineConfig({
   resolve: {
     alias: {
-      src: path.resolve(__dirname, '../src'),
+      src: '/src',
     },
   },
   plugins: [


### PR DESCRIPTION
[related](https://github.com/solidjs-community/solid-lib-starter/issues/3)

The `tsconfig` and `vite.config.ts` were not working nicely together prior to this patch:
Because of `baseUrl: '.'`, auto-imports would default to `src/.../Example` instead of `../../Example` which would create errors during `dev`, as these paths were not resolved in the `vite.config.ts`.

This PR adds a path-alias for `src` to `../src`.